### PR TITLE
modify carina-csi-config validate logic

### DIFF
--- a/pkg/configuration/config_test.go
+++ b/pkg/configuration/config_test.go
@@ -28,16 +28,16 @@ func TestUnmarshalWithDecoderOptions(t *testing.T) {
 			if rf != reflect.Map || rt != reflect.Struct {
 				return data, nil
 			}
-			mapstructure.Decode(data.(map[string]interface{}), &DiskConfig)
-			mapstructure.Decode(data.(map[string]interface{})["diskselector"], &DiskConfig.DiskSelectors)
+			mapstructure.Decode(data.(map[string]interface{}), &diskConfig)
+			mapstructure.Decode(data.(map[string]interface{})["diskselector"], &diskConfig.DiskSelectors)
 			return data, err
 		},
 	))
 
-	err = v.Unmarshal(&DiskConfig, opt)
+	err = v.Unmarshal(&diskConfig, opt)
 	if err != nil {
 		t.Fatalf("unable to decode into struct, %v", err)
 	}
-	log.Info(DiskConfig)
+	log.Info(diskConfig)
 
 }


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug
> /kind cleanup


**What this PR does / why we need it**:
1. remove legacy parameter ConfigProvider
2. modify some parameter and method scope
3. when carina-csi-config validate failed, the running node server will exit, it is best to ignore this change; when the node server starting, it should exit if carina-csi-config validate failed.

**Which issue(s) this PR fixes**:

Fixes #88 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
none
```
