### PR TITLE
fix bug for delete lv when node is not ready

### DIFF
--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -192,9 +192,9 @@ func (r *NodeReconciler) getNeedRebuildVolume(ctx context.Context) (map[string]c
 			continue
 		}
 
-		log.Infof("checkouk lv: %s", lv.Name)
+		log.Infof("checkout lv: %s", lv.Name)
 		if isSkip, err := r.skipLv(ctx, lv); isSkip || err != nil {
-			log.Errorf("skip lv Whether the pod.annotation meets the condition  in not ready node:%s  err:%s", lv.Spec.NodeName, err.Error())
+			log.Errorf("skip lv whether the pod.annotation meets the condition in not ready node:%s  err:%s", lv.Spec.NodeName, err.Error())
 			continue
 		}
 

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/carina-io/carina"
 	"strings"
 	"time"
+
+	"github.com/carina-io/carina"
 
 	carinav1 "github.com/carina-io/carina/api/v1"
 	"github.com/carina-io/carina/utils"
@@ -191,6 +192,12 @@ func (r *NodeReconciler) getNeedRebuildVolume(ctx context.Context) (map[string]c
 			continue
 		}
 
+		log.Infof("checkouk lv: %s", lv.Name)
+		if isSkip, err := r.skipLv(ctx, lv); isSkip || err != nil {
+			log.Errorf("skip lv Whether the pod.annotation meets the condition  in not ready node:%s  err:%s", lv.Spec.NodeName, err.Error())
+			continue
+		}
+
 		log.Infof("start clear pod: %s", lv.Spec.NodeName)
 		err := r.clearPod(ctx, lv.Spec.NodeName)
 		if err != nil {
@@ -340,4 +347,29 @@ func (r *NodeReconciler) killPod(ctx context.Context, pod *corev1.Pod) error {
 	}
 	log.Infof("delete pod namespace: %s name: %s", pod.Namespace, pod.Name)
 	return nil
+}
+
+//skip rebuild lv when pod.annotation "carina.storage.io/allow-pod-migration-if-node-notready: false" or none
+func (r *NodeReconciler) skipLv(ctx context.Context, lv carinav1.LogicVolume) (bool, error) {
+	podList := &corev1.PodList{}
+	err := r.Client.List(ctx, podList, client.MatchingFields{"combinedIndex": fmt.Sprintf("%s-%s", carina.CarinaSchedule, lv.Spec.NodeName)})
+	if err != nil {
+		return false, err
+	}
+	for _, p := range podList.Items {
+		for _, vol := range p.Spec.Volumes {
+			if vol.PersistentVolumeClaim == nil {
+				continue
+			}
+			if vol.PersistentVolumeClaim.ClaimName != lv.Spec.Pvc {
+				continue
+			}
+			// check annotation carina.storage.io/allow-pod-migration-if-node-notready: true
+			if _, ok := p.Annotations[carina.AllowPodMigrationIfNodeNotready]; !ok || p.Annotations[carina.AllowPodMigrationIfNodeNotready] == "false" {
+				return true, nil
+			}
+
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
skip rebuid lv when pod.annotation has none or not need to rebuid
```
