### PR TITLE
fix: remove redundant partprobe for lvm

### DIFF
--- a/pkg/devicemanager/lvmd/interface.go
+++ b/pkg/devicemanager/lvmd/interface.go
@@ -66,6 +66,4 @@ type Lvm2 interface {
 	StartLvm2() error
 	// RemoveUnknownDevice 清理unknown设备
 	RemoveUnknownDevice(vg string) error
-	// PartProbe 同步分区表
-	PartProbe() error
 }

--- a/pkg/devicemanager/lvmd/lvm.go
+++ b/pkg/devicemanager/lvmd/lvm.go
@@ -364,7 +364,3 @@ func (lv2 *Lvm2Implement) StartLvm2() error {
 func (lv2 *Lvm2Implement) RemoveUnknownDevice(vg string) error {
 	return lv2.Executor.ExecuteCommand("vgreduce", "--removemissing", vg)
 }
-
-func (lv2 *Lvm2Implement) PartProbe() error {
-	return lv2.Executor.ExecuteCommand("bash", "-c", "partprobe")
-}

--- a/runners/devicecheck.go
+++ b/runners/devicecheck.go
@@ -50,7 +50,7 @@ func NewDeviceCheck(dm *deviceManager.DeviceManager) manager.Runnable {
 }
 
 func (dc *deviceCheck) Start(ctx context.Context) error {
-	log.Info("start device scan...")
+	log.Info("Starting device scan...")
 	dc.dm.VolumeManager.RefreshLvmCache()
 	// 服务启动先检查一次
 	dc.addAndRemoveDevice()
@@ -150,10 +150,6 @@ func (dc *deviceCheck) addAndRemoveDevice() {
 			if err = dc.dm.VolumeManager.AddNewDiskToVg(pv, vg); err != nil {
 				log.Errorf("add new disk failed vg: %s, disk: %s, error: %v", vg, pv, err)
 			}
-			//同步磁盘分区表
-			if err = dc.dm.VolumeManager.GetLv().PartProbe(); err != nil {
-				log.Errorf("failed partprobe  error: %v", err)
-			}
 		}
 	}
 
@@ -188,10 +184,6 @@ func (dc *deviceCheck) addAndRemoveDevice() {
 				log.Infof("try to remove pv %s from vg %s", pv.PVName, v.VGName)
 				if err := dc.dm.VolumeManager.RemoveDiskInVg(pv.PVName, v.VGName); err != nil {
 					log.Errorf("remove pv %s error %v", pv.PVName, err)
-					continue
-				}
-				if err := dc.dm.VolumeManager.GetLv().PartProbe(); err != nil {
-					log.Errorf("failed partprobe  error: %v", err)
 					continue
 				}
 				log.Infof("succeeded in removing pv %s from vg %s", pv.PVName, v.VGName)

--- a/runners/troubleshoot.go
+++ b/runners/troubleshoot.go
@@ -54,6 +54,7 @@ func NewTroubleShoot(dm *deviceManager.DeviceManager) manager.Runnable {
 }
 
 func (t *troubleShoot) Start(ctx context.Context) error {
+	log.Info("Starting troubleshoot...")
 	ticker := time.NewTicker(600 * time.Second)
 	defer ticker.Stop()
 	for {


### PR DESCRIPTION
> /kind bug

**What this PR does / why we need it**:
After adding pv to vg, partprobe operation is not required

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
none
```
