### PR TITLE
fix bug when extent raw disk with block device

### DIFF
--- a/pkg/devicemanager/partition/partition_test.go
+++ b/pkg/devicemanager/partition/partition_test.go
@@ -130,6 +130,17 @@ func TestGetPartitions(t *testing.T) {
 
 }
 
+func TestMount(t *testing.T) {
+
+	targetPathOut, err := localparttion.Executor.ExecuteCommandWithOutput("/usr/bin/findmnt", "-S ", "/dev/sda", "--noheadings", "--output=target")
+	//t.Log("/usr/bin/findmnt", " -S ", "/dev/sda", " --noheadings", " --output=target", " targetPathOut: "+targetPathOut)
+	t.Log(err.Error())
+	targetpath := strings.TrimSpace(strings.TrimSuffix(strings.ReplaceAll(targetPathOut, "\"", ""), "\n"))
+	flag := strings.Contains(targetpath, "/dev")
+	t.Log(flag)
+	t.Log("len:", len(targetpath))
+}
+
 func TestCreatePartition(t *testing.T) {
 	//name: 54cd2f39cf95 group: carina-raw-loop size: 13958643712
 	size := 4747316223


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes：  the problem that block devices cannot be expanded

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```
