### PR TITLE
fix(psp): disable from 1.25

### DIFF
--- a/charts/templates/csi-controller-psp.yaml
+++ b/charts/templates/csi-controller-psp.yaml
@@ -1,4 +1,4 @@
- {{- if semverCompare "<= 1.25-0" (include "carina.kubeVersion" .) -}}
+ {{- if semverCompare "< 1.25-0" (include "carina.kubeVersion" .) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -65,4 +65,4 @@ roleRef:
   kind: Role
   name: {{ .Values.controller.name }}-psp
   apiGroup: rbac.authorization.k8s.io
-{{- end }}  
+{{- end }}

--- a/charts/templates/csi-node-psp.yaml
+++ b/charts/templates/csi-node-psp.yaml
@@ -1,4 +1,4 @@
- {{- if semverCompare "<= 1.25-0" (include "carina.kubeVersion" .) -}}
+ {{- if semverCompare "< 1.25-0" (include "carina.kubeVersion" .) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -85,4 +85,4 @@ roleRef:
   kind: Role
   name: {{ .Values.node.name }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}   
+{{- end }}


### PR DESCRIPTION
Podsecuritypolicies are removed in k8s 1.25 and above.

Chart test included 1.25.