### PR TITLE
Fix missing error check for os.Stat in UnbindMount

### DIFF
--- a/pkg/csidriver/filesystem/host.go
+++ b/pkg/csidriver/filesystem/host.go
@@ -63,8 +63,11 @@ func BindMount(source, target string) error {
 // UnbindMount 解除目标目录上的绑定挂载
 func UnbindMount(target string) error {
 	// 验证目标目录是否存在
-	if _, err := os.Stat(target); os.IsNotExist(err) {
-		return fmt.Errorf("目标目录不存在或不是一个目录: %s", target)
+	if _, err := os.Stat(target); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("目标目录不存在或不是一个目录: %s", target)
+		}
+		return fmt.Errorf("无法访问目标目录: %s, 错误: %v", target, err)
 	}
 
 	// 执行 umount 命令


### PR DESCRIPTION
## Summary

The `UnbindMount` function in `pkg/csidriver/filesystem/host.go` calls `os.Stat(target)` but only checks for `os.IsNotExist(err)`. If `os.Stat` returns any other error (e.g., permission denied, I/O error), the error is silently ignored and the function proceeds to attempt umount on a potentially invalid path.

## Changes

Modified the error handling in `UnbindMount` to:
1. Check for any error from `os.Stat`, not just `os.IsNotExist`
2. Return a specific error for non-existent paths
3. Return a generic error with details for other access errors

## Before
```go
if _, err := os.Stat(target); os.IsNotExist(err) {
    return fmt.Errorf("目标目录不存在或不是一个目录: %s", target)
}
```

## After
```go
if _, err := os.Stat(target); err != nil {
    if os.IsNotExist(err) {
        return fmt.Errorf("目标目录不存在或不是一个目录: %s", target)
    }
    return fmt.Errorf("无法访问目标目录: %s, 错误: %v", target, err)
}
```

## Testing

The fix ensures that:
- Non-existent paths return the original error message
- Permission denied errors are properly reported
- I/O errors are properly reported
- The function no longer silently ignores errors

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.